### PR TITLE
Tweaks to API

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -15,3 +15,5 @@ DB_NAME=mpc-rails-db-local
 # or a local mock server or a docker container.
 #
 HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+HMPPS_PRISONER_SEARCH_API_URL=https://prisoner-search-dev.prison.service.justice.gov.uk
+HMPPS_PRISON_API_URL=https://prison-api-dev.prison.service.justice.gov.uk

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/allocations/AllocationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/allocations/AllocationHistory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.managepomcasesapi.allocations
 
 import jakarta.persistence.Column
+import jakarta.persistence.Convert
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -13,6 +14,7 @@ import jakarta.validation.constraints.NotNull
 import org.hibernate.annotations.ColumnDefault
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.UpdateTimestamp
+import uk.gov.justice.digital.hmpps.managepomcasesapi.data.RecommendedPomTypeAttributeConverter
 import java.time.Instant
 
 enum class TierType(val tier: String) {
@@ -118,7 +120,7 @@ class AllocationHistory(
   @Column(name = "primary_pom_allocated_at")
   var primaryPomAllocatedAt: Instant? = null,
 
-  @Enumerated(EnumType.STRING)
+  @Convert(converter = RecommendedPomTypeAttributeConverter::class)
   @Column(name = "recommended_pom_type")
   var recommendedPomType: RecommendedPomType? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/data/RecommendedPomTypeAttributeConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/data/RecommendedPomTypeAttributeConverter.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.managepomcasesapi.data
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+import uk.gov.justice.digital.hmpps.managepomcasesapi.allocations.RecommendedPomType
+import java.util.Locale
+
+@Converter(autoApply = true)
+class RecommendedPomTypeAttributeConverter : AttributeConverter<RecommendedPomType, String> {
+  override fun convertToDatabaseColumn(pomType: RecommendedPomType): String = pomType.name.lowercase(Locale.getDefault())
+  override fun convertToEntityAttribute(dbData: String): RecommendedPomType = RecommendedPomType.valueOf(dbData.uppercase(Locale.getDefault()))
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/parole/ParoleCasesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/parole/ParoleCasesService.kt
@@ -15,8 +15,6 @@ class ParoleCasesService(
     val allocatedCases = allocatedCasesService.forPrison(prisonCode).associateBy { it.caseId }
     val paroleReviews = paroleReviewsRepository.findByCaseIdIn(allocatedCases.keys.toList())
 
-    print(allocatedCases)
-
     return paroleReviews
       .map {
         ParoleCase(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/service/PrisonerSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/service/PrisonerSearchService.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.managepomcasesapi.service
 
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -14,11 +16,14 @@ class PrisonerSearchService(
   fun findByPrison(prisonCode: String): List<CaseData> {
     val results = mutableListOf<CaseData>()
     var moreResultsToRead = true
-    var page = 1
+    var page = 0 // Zero-based page index
+    val size = 1000 // The size of the page to be returned
 
     while (moreResultsToRead) {
       val response = prisonerSearchApiWebClient.get()
-        .uri("/prisoner-search/prison/{prisonCode}?page={page}", prisonCode, page)
+        .uri("/prisoner-search/prison/{prisonCode}?page={page}&size={size}", prisonCode, page, size)
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+        .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
         .retrieve()
         .bodyToMono(PaginatedResponse::class.java)
         .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -3,14 +3,14 @@ hmpps-auth:
 
 api:
   client:
-    id: "example-api-client"
-    secret: "example-api-client-secret"
+    id: "${API_CLIENT_ID}"
+    secret: "${API_CLIENT_SECRET}"
 
 hmpps-prisoner-search-api:
-  url: "http://localhost:8080"
+  url: "${HMPPS_PRISONER_SEARCH_API_URL:http://localhost:8080}"
 
 hmpps-prison-api:
-  url: "http://localhost:8080"
+  url: "${HMPPS_PRISON_API_URL:http://localhost:8080}"
 
 spring:
   config:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/support/StubbedRequests.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/support/StubbedRequests.kt
@@ -14,6 +14,7 @@ class StubbedRequests(private val webClient: WebClient) {
 
     Mockito.`when`(webClient.get()).thenReturn(requestBodyUriSpec)
     Mockito.`when`(requestBodyUriSpec.uri(path, params)).thenReturn(requestBodySpec)
+    Mockito.`when`(requestBodySpec.header(Mockito.anyString(), Mockito.anyString())).thenReturn(requestBodySpec)
     Mockito.`when`(requestBodySpec.retrieve()).thenReturn(responseSpec)
     Mockito.`when`(responseSpec.bodyToMono(response::class.java)).thenReturn(Mono.just(response))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/unit/service/PrisonerSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/unit/service/PrisonerSearchServiceTest.kt
@@ -40,9 +40,10 @@ class PrisonerSearchServiceTest {
 
     paginatedResponses.forEachIndexed { i, response ->
       stubbedRequests.get(
-        "/prisoner-search/prison/{prisonCode}?page={page}",
+        "/prisoner-search/prison/{prisonCode}?page={page}&size={size}",
         "LEI",
-        i + 1,
+        i,
+        1000,
         response = response,
       )
     }


### PR DESCRIPTION
Turns out without the "Content-Type" header the call would fail.

Also found an issue with the RecommendedPomType when reading from DB as lowercase.

Config changes to make it easier to run locally.