### PR TITLE
Handle unexpected prison-api errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/client/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/client/PrisonApiClient.kt
@@ -29,8 +29,12 @@ class PrisonApiClient(@Qualifier("prisonApiWebClient") private val webClient: We
     .retrieve()
     .bodyToMono(Boolean::class.java)
     .onErrorResume { e ->
-      LOG.error("hasPomRole: ${e.message}")
-      Mono.just(false)
+      LOG.error("hasPomRole: {}", e.message)
+      if (e is WebClientResponseException.NotFound) {
+        Mono.just(false)
+      } else {
+        Mono.error(e)
+      }
     }
     .block()!!
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/poms/PomController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/poms/PomController.kt
@@ -44,5 +44,5 @@ class PomController(
   fun hasPomAtPrison(
     @PathVariable(name = "staffId") staffId: Int,
     @PathVariable(name = "prisonCode") prisonCode: String,
-  ) = staffService.hasPomRole(staffId, prisonCode)
+  ): Boolean = staffService.hasPomRole(staffId, prisonCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/service/StaffService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/service/StaffService.kt
@@ -8,5 +8,5 @@ class StaffService(
   private val prisonApiClient: PrisonApiClient,
 ) {
   fun staffDetail(staffId: Int) = prisonApiClient.staffDetail(staffId)
-  fun hasPomRole(staffId: Int, agencyId: String) = prisonApiClient.hasPomRole(staffId, agencyId)
+  fun hasPomRole(staffId: Int, agencyId: String): Boolean = prisonApiClient.hasPomRole(staffId, agencyId)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/integration/poms/PomControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/integration/poms/PomControllerIntTest.kt
@@ -53,7 +53,7 @@ class PomControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `should return true if staff member is a POM in the prison`() {
-      prisonApi.stubHasPomRoleResponse("true")
+      prisonApi.stubHasPomRoleResponse(200, "true")
 
       webTestClient.get()
         .uri(POM_URI, 12345, "LEI")
@@ -67,7 +67,7 @@ class PomControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `should return false if staff member is not a POM in the prison`() {
-      prisonApi.stubHasPomRoleResponse("false")
+      prisonApi.stubHasPomRoleResponse(200, "false")
 
       webTestClient.get()
         .uri(POM_URI, 12345, "LEI")
@@ -77,6 +77,32 @@ class PomControllerIntTest : IntegrationTestBase() {
         .isOk
         .expectBody(Boolean::class.java)
         .isEqualTo(false)
+    }
+
+    @Test
+    fun `should return false if prison API returns a 404`() {
+      prisonApi.stubHasPomRoleResponse(404)
+
+      webTestClient.get()
+        .uri(POM_URI, 12345, "LEI")
+        .headers(setAuthorisation(roles = listOf("ROLE_MANAGE_POM_CASES__MANAGE_POM_CASES_UI")))
+        .exchange()
+        .expectStatus()
+        .isOk
+        .expectBody(Boolean::class.java)
+        .isEqualTo(false)
+    }
+
+    @Test
+    fun `should return error if prison API returns an error other than 404`() {
+      prisonApi.stubHasPomRoleResponse(500)
+
+      webTestClient.get()
+        .uri(POM_URI, 12345, "LEI")
+        .headers(setAuthorisation(roles = listOf("ROLE_MANAGE_POM_CASES__MANAGE_POM_CASES_UI")))
+        .exchange()
+        .expectStatus()
+        .is5xxServerError
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/managepomcasesapi/integration/wiremock/PrisonApiMockServer.kt
@@ -22,12 +22,12 @@ class PrisonApiMockServer : WireMockServer(8093) {
     )
   }
 
-  fun stubHasPomRoleResponse(response: String = "true") {
+  fun stubHasPomRoleResponse(status: Int = 200, response: String = "") {
     stubFor(
       get(urlPathMatching("/prison-api/api/staff/[0-9]+/[A-Z]{3}/roles/POM")).willReturn(
         aResponse()
           .withHeader("Content-Type", "application/json")
-          .withStatus(200)
+          .withStatus(status)
           .withBody(response),
       ),
     )


### PR DESCRIPTION
Instead of silently falling back to "false", otherwise we might be hiding functionality from MPC UI when there are API failures and not knowing.

Only error we don't care is a not found returned if the prisonCode does not exist or is not valid so we fallback to false.